### PR TITLE
feat(FR-6): sync recipe to Hostinger via FTP after add

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
+        "basic-ftp": "^5.2.0",
         "commander": "^12.0.0",
         "dotenv": "^17.3.1",
         "puppeteer": "^24.37.5",

--- a/cli/package.json
+++ b/cli/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
+    "basic-ftp": "^5.2.0",
     "commander": "^12.0.0",
     "dotenv": "^17.3.1",
     "puppeteer": "^24.37.5",

--- a/cli/src/commands/add.test.ts
+++ b/cli/src/commands/add.test.ts
@@ -5,6 +5,7 @@ import * as browserService from '../services/browser.js';
 import * as extractorService from '../services/extractor.js';
 import * as storageService from '../services/storage.js';
 import * as failures from '../lib/failures.js';
+import * as ftpService from '../services/ftp.js';
 import { UserError } from '../lib/errors.js';
 
 vi.mock('../lib/url.js');
@@ -12,6 +13,7 @@ vi.mock('../services/browser.js');
 vi.mock('../services/extractor.js');
 vi.mock('../services/storage.js');
 vi.mock('../lib/failures.js');
+vi.mock('../services/ftp.js');
 
 const defaultOptions = { ftp: true, images: true };
 
@@ -243,5 +245,38 @@ describe('addCommand', () => {
     await expect(
       addCommand('https://example.com/', { ftp: false, images: true })
     ).resolves.toBeUndefined();
+  });
+
+  it('calls syncRecipe with the recipe id when ftp: true', async () => {
+    vi.mocked(urlLib.parseUrl).mockReturnValue(new URL('https://example.com/'));
+    vi.mocked(urlLib.checkReachable).mockResolvedValue(undefined);
+    vi.mocked(browserService.renderPage).mockResolvedValue({
+      html: '<html></html>',
+      imageCandidates: [],
+    });
+    vi.mocked(extractorService.extract).mockResolvedValue(mockExtracted);
+    vi.mocked(storageService.saveRecipe).mockResolvedValue(mockRecipe);
+    vi.mocked(ftpService.syncRecipe).mockResolvedValue(undefined);
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await addCommand('https://example.com/', { ftp: true, images: true });
+
+    expect(ftpService.syncRecipe).toHaveBeenCalledWith('test-uuid-1234');
+  });
+
+  it('does not call syncRecipe when --no-ftp (ftp: false)', async () => {
+    vi.mocked(urlLib.parseUrl).mockReturnValue(new URL('https://example.com/'));
+    vi.mocked(urlLib.checkReachable).mockResolvedValue(undefined);
+    vi.mocked(browserService.renderPage).mockResolvedValue({
+      html: '<html></html>',
+      imageCandidates: [],
+    });
+    vi.mocked(extractorService.extract).mockResolvedValue(mockExtracted);
+    vi.mocked(storageService.saveRecipe).mockResolvedValue(mockRecipe);
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await addCommand('https://example.com/', { ftp: false, images: true });
+
+    expect(ftpService.syncRecipe).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/commands/add.ts
+++ b/cli/src/commands/add.ts
@@ -5,6 +5,7 @@ import { logFailure } from '../lib/failures.js';
 import { renderPage } from '../services/browser.js';
 import { extract } from '../services/extractor.js';
 import { saveRecipe } from '../services/storage.js';
+import { syncRecipe } from '../services/ftp.js';
 
 export interface AddOptions {
   // Populated by --tags <tags>; merged with auto-tags in FR-4
@@ -19,7 +20,8 @@ export async function addCommand(url: string, options: AddOptions): Promise<void
   // Step 1: Validate URL format — throws UserError on failure (not logged; no valid URL yet)
   const parsed = parseUrl(url);
 
-  // Steps 2+: URL is valid — any failure from here is logged to failures.log
+  // Steps 2–4: URL is valid — any failure from here is logged to failures.log
+  let recipeId: string;
   try {
     // Step 2: Check reachability — unreachable URLs are logged per spec
     await checkReachable(parsed.href);
@@ -33,6 +35,7 @@ export async function addCommand(url: string, options: AddOptions): Promise<void
     // Step 4 (FR-5): Persist recipe to file-based database
     const recipe = await saveRecipe(extracted, parsed.href);
     info(`Saved recipe: ${recipe.id}`);
+    recipeId = recipe.id;
   } catch (e: unknown) {
     const reason = e instanceof Error ? e.message : String(e);
     // logFailure is best-effort; don't let its failure mask the original error
@@ -44,5 +47,9 @@ export async function addCommand(url: string, options: AddOptions): Promise<void
     throw e;
   }
 
-  // FTP sync (FR-6) will be added in subsequent stories
+  // Step 5 (FR-6): FTP sync — outside logFailure try/catch; FTP errors are deployment concerns
+  if (options.ftp) {
+    await syncRecipe(recipeId);
+    info('FTP sync complete.');
+  }
 }

--- a/cli/src/services/ftp.ts
+++ b/cli/src/services/ftp.ts
@@ -1,0 +1,58 @@
+import { Client } from 'basic-ftp';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { UserError } from '../lib/errors.js';
+import { info } from '../lib/logger.js';
+
+// Same path derivation pattern as storage.ts
+const DATA_DIR = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../data/recipes'
+);
+
+interface FtpCredentials {
+  host: string;
+  user: string;
+  password: string;
+  remotePath: string;
+}
+
+function getCredentials(): FtpCredentials {
+  const host = process.env.FTP_HOST;
+  const user = process.env.FTP_USER;
+  const password = process.env.FTP_PASS;
+  const remotePath = process.env.FTP_REMOTE_DATA_PATH;
+
+  if (!host || !user || !password || !remotePath) {
+    throw new UserError(
+      'FTP credentials are not fully configured. Set FTP_HOST, FTP_USER, FTP_PASS, and FTP_REMOTE_DATA_PATH in .env. Use --no-ftp to skip.'
+    );
+  }
+
+  return { host, user, password, remotePath };
+}
+
+export async function syncRecipe(id: string): Promise<void> {
+  const { host, user, password, remotePath } = getCredentials();
+  const client = new Client();
+
+  try {
+    await client.access({ host, user, password, secure: true });
+    await client.ensureDir(remotePath);
+
+    const recipeFile = resolve(DATA_DIR, `${id}.json`);
+    const indexFile = resolve(DATA_DIR, 'index.json');
+
+    await client.uploadFrom(recipeFile, `${id}.json`);
+    info(`FTP: uploaded ${id}.json`);
+
+    await client.uploadFrom(indexFile, 'index.json');
+    info(`FTP: uploaded index.json`);
+  } catch (e: unknown) {
+    if (e instanceof UserError) throw e;
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new UserError(`FTP upload failed: ${msg}`);
+  } finally {
+    client.close();
+  }
+}


### PR DESCRIPTION
## Summary
- New `cli/src/services/ftp.ts` service: exports `syncRecipe(id)` using `basic-ftp`
- Validates all 4 FTP env vars eagerly; throws `UserError` with a clear message if any are missing
- After `client.ensureDir(remotePath)`, uploads `<uuid>.json` then `index.json`; wraps FTP errors as `UserError`
- `add.ts` calls `syncRecipe(recipeId)` after `saveRecipe` succeeds, outside the `logFailure` try/catch; guarded by `options.ftp` for `--no-ftp` flag
- Local data is never rolled back on FTP failure (write completes before FTP runs)
- `basic-ftp ^5.2.0` added as production dependency

## Acceptance Criteria
- [x] After a successful local write, the new recipe JSON file is uploaded via FTP to `/data/recipes/`
- [x] The `index.json` is also re-uploaded after each addition
- [x] FTP credentials are read from `.env` (never committed to git)
- [x] Upload errors are reported clearly; local data is never rolled back on FTP failure
- [x] A `--no-ftp` flag skips the upload for offline use

## Test plan
- [ ] All 86 existing tests pass (`npm test` from `cli/`)
- [ ] TypeScript compiles clean (`npm run typecheck` from `cli/`)
- [ ] Run `recipe add <url>` with valid FTP credentials — recipe JSON and `index.json` should appear on Hostinger
- [ ] Run `recipe add <url> --no-ftp` — FTP is skipped, recipe saved locally only
- [ ] Run with missing FTP env vars — clear `UserError` message printed to stderr, exit 1

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)