### PR TITLE
feat(FR-14): manually set image URLs for a recipe

### DIFF
--- a/viewer/php/api/image.php
+++ b/viewer/php/api/image.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * GET /api/image?id=<uuid>&n=<1|2>
+ * GET /api/image?id=<uuid>&n=<positive integer>
  * Streams a recipe image (JPEG) from the data directory.
  * Validates both parameters before constructing any file path.
  */
@@ -17,10 +17,10 @@ if (!preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$
     exit;
 }
 
-// Validate image index
-if ($n !== '1' && $n !== '2') {
+// Validate image index (positive integer)
+if (!preg_match('/^[1-9][0-9]*$/', $n)) {
     http_response_code(400);
-    echo 'Invalid n (must be 1 or 2)';
+    echo 'Invalid n (must be a positive integer)';
     exit;
 }
 


### PR DESCRIPTION
## Summary
- Adds `recipe set-images <uuid> <url...>` CLI command to manually assign image URLs to a recipe
- Adds `POST /api/set-images` PHP endpoint for setting images from the viewer
- Adds image carousel UI component with paste, reorder, and remove support
- Fixes image API endpoint to allow more than 2 images (removes hardcoded n=1|2 limit)

## Test plan
- [ ] Run `recipe set-images <uuid> <url1> <url2> <url3>` and verify images are saved and FTP-synced
- [ ] Open a recipe in the viewer, use the carousel to paste/reorder/remove images
- [ ] Verify `/api/image?id=<uuid>&n=3` returns the third image (previously returned 400)
- [ ] Verify invalid UUIDs and non-positive `n` values still return 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)